### PR TITLE
Change RAILS_ROOT because of depreciation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ desc %q{
 Create a dictionary file from web content (xml or html).
 Writes to the directory specified by Forgery::FileWriter#write_to!
 '${GEM_HOME}/lib/forgery/dictionaries' by default (standalone)
-'${RAILS_ROOT}/lib/forgery/dictionaries' by default (as a Rails 3 plugin)
+'${Rails.root}/lib/forgery/dictionaries' by default (as a Rails 3 plugin)
 
 Parameters:
 :dictionary_name  -- the name of your new dictionary file

--- a/lib/forgery/extensions/string.rb
+++ b/lib/forgery/extensions/string.rb
@@ -4,7 +4,7 @@ class String
   end
 
   # Ripped right out of rails
-  if !defined?(RAILS_ROOT)
+  if !defined?(Rails.root)
     def camelize(first_letter = :upper)
       case first_letter
       when :upper

--- a/lib/forgery/forgery_railtie.rb
+++ b/lib/forgery/forgery_railtie.rb
@@ -12,7 +12,7 @@ class ForgeryRailtie < Rails::Railtie
       Create a dictionary file from web content (xml or html).
       Writes to the directory specified by Forgery::FileWriter#write_to!
       '${GEM_HOME}/lib/forgery/dictionaries' by default (standalone)
-      '${RAILS_ROOT}/lib/forgery/dictionaries' by default (as a Rails 3 plugin)
+      '${Rails.root}/lib/forgery/dictionaries' by default (as a Rails 3 plugin)
 
       Parameters:
       :dictionary_name  -- the name of your new dictionary file

--- a/spec/forgery_spec.rb
+++ b/spec/forgery_spec.rb
@@ -41,11 +41,14 @@ describe Forgery do
     Forgery(:lorem_ipsum, :text, :sentences, 2)
   end
 
-  it "should return the rails root path if RAILS_ROOT is defined" do
+  it "should return the rails root path if Rails.root is defined" do
     RAILS_ROOT = '/path/from/rails/root/const'
     Forgery.rails_root.should == '/path/from/rails/root/const'
     Object.instance_eval { remove_const(:RAILS_ROOT) }
   end
+    RAILS_ROOT = '/path/from/rails/root/const'
+    Forgery.rails_root.should == '/path/from/rails/root/const'
+    Object.instance_eval { remove_const(:RAILS_ROOT) }
 
   it "should return the rails root path as a string if Rails.root is defined" do
     Rails = Object.new
@@ -54,7 +57,7 @@ describe Forgery do
     Object.instance_eval { remove_const(:Rails) }
   end
 
-  it "should return nil when RAILS_ROOT and Rails.root are not defined" do
+  it "should return nil when Rails.root and Rails.root are not defined" do
     Forgery.rails_root.should be_nil
   end
 


### PR DESCRIPTION
As per the title, I swapped `Rails.root` out for `RAILS_ROOT` where appropriate to avoid the depreciation warnings in Rails 3.  In hindsight, you might be trying to keep this backwards compatible for Rails 2.x users, so this straightforward approach might not be the preferred one.  Let me know if I should try to make this change conditional.
