### PR TITLE
Rake has to be required to let Forgery work with 3.1

### DIFF
--- a/lib/forgery/forgery_railtie.rb
+++ b/lib/forgery/forgery_railtie.rb
@@ -1,5 +1,6 @@
 require 'forgery'
 require 'rails'
+require 'rake'
 
 class ForgeryRailtie < Rails::Railtie
   extend Rake::DSL


### PR DESCRIPTION
Require rake in railty.
