### PR TITLE
Adding an error message when file was not found during dictionary lookup

### DIFF
--- a/lib/forgery/file_reader.rb
+++ b/lib/forgery/file_reader.rb
@@ -31,6 +31,7 @@ class Forgery
         file = "#{path}/#{folder}/#{name}"
         return file if File.exists?(file)
       end
+      raise ArgumentError.new("File '#{name}' wasn't found in '#{folder}' folder. Searched paths: \n#{Forgery.load_paths.join('\n')}")
     end
   end
 end

--- a/spec/file_reader_spec.rb
+++ b/spec/file_reader_spec.rb
@@ -19,6 +19,11 @@ describe Forgery::FileReader do
     Forgery::FileReader.read_dictionary(:code_names).should include('Shiretoko')
   end
 
+  it "should raise an exception if file wasn't found in load paths" do
+    lambda {
+      Forgery::FileReader.read_dictionary(:non_existing_dictionary)
+    }.should raise_error(ArgumentError)
+  end
   after do
     # reset load_paths
     Forgery.load_paths.clear


### PR DESCRIPTION
Right now, if dictionary file is not found, I get the following error:

```
  can't convert Array into String
  /Users/alexp/.rvm/gems/ruby-1.9.2-p136/gems/forgery-0.5.0/lib/forgery/file_reader.rb:21:in `foreach'
  /Users/alexp/.rvm/gems/ruby-1.9.2-p136/gems/forgery-0.5.0/lib/forgery/file_reader.rb:21:in `read_file'
  /Users/alexp/.rvm/gems/ruby-1.9.2-p136/gems/forgery-0.5.0/lib/forgery/file_reader.rb:7:in `read_dictionary'
  /Users/alexp/.rvm/gems/ruby-1.9.2-p136/gems/forgery-0.5.0/lib/forgery/dictionaries.rb:11:in `[]'
```

That happens because FileReader#find_file may return String, in case file is found and Array when file is not found.

Pull requests adds raising an exception that would make it easier for people to understand what exactly they've done wrong (I assume that i'm not the only inattentive person who may put wrong file names). 

Thanks for the awesome project. It helped me not once already. Right now we're using it to empower @travis-ci tests / load fake data for development.
