### PR TITLE
avoiding white spaces in domain_name and email_address

### DIFF
--- a/lib/forgery/forgery/internet.rb
+++ b/lib/forgery/forgery/internet.rb
@@ -1,7 +1,7 @@
 class Forgery::Internet < Forgery
 
   def self.user_name
-    (dictionaries[:male_first_names].random[0,1] + dictionaries[:last_names].random).downcase
+    (dictionaries[:male_first_names].random[0,1] + dictionaries[:last_names].random).downcase.strip.gsub(' ','_')
   end
 
   def self.top_level_domain
@@ -9,7 +9,7 @@ class Forgery::Internet < Forgery
   end
 
   def self.domain_name
-    dictionaries[:company_names].random.downcase + '.' + self.top_level_domain
+    dictionaries[:company_names].random.downcase.strip.gsub(' ','_') + '.' + self.top_level_domain
   end
 
   def self.email_address


### PR DESCRIPTION
Hi

thanks for forgery

I just added a check to avoid whitespaces in email address and domain name because I had to use customized dictionaries with more realistic surnames and company names composed by more than one word

bye
