### PR TITLE
add ipv6 method to Forgery::Internet

### DIFF
--- a/lib/forgery/forgery/internet.rb
+++ b/lib/forgery/forgery/internet.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 class Forgery::Internet < Forgery
 
   def self.user_name
@@ -26,6 +28,11 @@ class Forgery::Internet < Forgery
 
   def self.ip_v4
     (1..4).map{rand(256)}.join('.')
+  end
+
+  # credit for this method from http://stackoverflow.com/a/2811349/793330
+  def self.ip_v6
+    IPAddr.new(rand(2**128),Socket::AF_INET6).to_s
   end
 
 end

--- a/spec/forgery/internet_spec.rb
+++ b/spec/forgery/internet_spec.rb
@@ -50,4 +50,13 @@ describe Forgery::Internet do
       end
     end
   end
+
+  describe '.ip_v6' do
+    it 'should be a valid ipv6 address' do
+      val = Forgery::Internet.ip_v6
+      address = IPAddr.new(val)
+      address.ipv6?.should eq(true)
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'rubygems'
 require 'bundler/setup'
 require 'forgery'
+require 'ipaddr'
 
 ENV["TESTING_VIA_RSPEC"] = "true"
 


### PR DESCRIPTION
This leverages the ruby IPAddr class to create a random IPV6 address. 
