### PR TITLE
Remove Ulaan Bataar timezone

### DIFF
--- a/lib/forgery/dictionaries/zones
+++ b/lib/forgery/dictionaries/zones
@@ -114,7 +114,6 @@ Kuala Lumpur
 Perth
 Singapore
 Taipei
-Ulaan Bataar
 Urumqi
 Osaka
 Sapporo


### PR DESCRIPTION
This timezone was present in Rails3, but was renamed to 'Ulaanbataar' in Rails4.
So while upgrading an app to Rails4 it sometimes would pop up when generating fake data and throw
exceptions because it's not a valid name. I propose removing it in order to assure the gem won't
generate invalid data for Rails 3 or 4, but I'm happy with a rename too.

Just FYI, these are the differences between Rails4 `rake time:zones:all` and the forgery zones dictionary

```
+ Montevideo
- Ulaan Bataar
+ Ulaanbaatar
+ Chatham Is.
+ Tokelau Is.
```

So just this name change and 3 extra timezones not in the gem. None of them is a problem apart from the subject of this issue.

Editted: corrected formatting
