### PR TITLE
Proposition for LoremIpsum#paragraphs()

### DIFF
--- a/lib/forgery/forgery/lorem_ipsum.rb
+++ b/lib/forgery/forgery/lorem_ipsum.rb
@@ -88,13 +88,13 @@ class Forgery::LoremIpsum < Forgery
       paragraph
     }
     enumer = Enumerator.new { |yielder|
-      (count - 1).times do yielder.yield next_paragraph.call end
-      yielder.yield next_paragraph.call
+      (count - 1).times do yielder.yield next_paragraph.call, options[:separator] end
+      yielder.yield next_paragraph.call, nil
     }
 
     if block_given?
-      then enumer.each do |par| yield par end
-      else enumer.to_a.join(options[:separator])
+      then enumer.each do |par, sep| yield par, sep end
+      else enumer.to_a.join
     end
   end
 

--- a/lib/forgery/forgery/lorem_ipsum.rb
+++ b/lib/forgery/forgery/lorem_ipsum.rb
@@ -75,18 +75,20 @@ class Forgery::LoremIpsum < Forgery
     range = range_from_quantity(quantity, options)
     start = range.first * options[:sentences]
 
-    paragraphs = []
-
-    range.to_a.length.times do |i|
-      paragraphs << (
+    enumer = range.to_a.length.enum_for(:times).lazy.map do
+      paragraph = (
         options[:wrap][:start] +
         dictionaries[:lorem_ipsum][start..(start+options[:sentences]-1)].join(" ") +
         options[:wrap][:end]
       )
       start += options[:sentences]
+      paragraph
     end
 
-    paragraphs.join(options[:separator])
+    if block_given?
+      then enumer.each do |par| yield par end
+      else enumer.to_a.join(options[:separator])
+    end
   end
 
   def self.title(options={})

--- a/lib/forgery/forgery/lorem_ipsum.rb
+++ b/lib/forgery/forgery/lorem_ipsum.rb
@@ -74,8 +74,11 @@ class Forgery::LoremIpsum < Forgery
 
     range = range_from_quantity(quantity, options)
     start = range.first * options[:sentences]
+    count = range.count
 
-    enumer = range.count.enum_for(:times).lazy.map do
+    return '' if count == 0
+
+    next_paragraph = proc {
       paragraph = (
         options[:wrap][:start] +
         dictionaries[:lorem_ipsum][start..(start+options[:sentences]-1)].join(" ") +
@@ -83,7 +86,11 @@ class Forgery::LoremIpsum < Forgery
       )
       start += options[:sentences]
       paragraph
-    end
+    }
+    enumer = Enumerator.new { |yielder|
+      (count - 1).times do yielder.yield next_paragraph.call end
+      yielder.yield next_paragraph.call
+    }
 
     if block_given?
       then enumer.each do |par| yield par end

--- a/lib/forgery/forgery/lorem_ipsum.rb
+++ b/lib/forgery/forgery/lorem_ipsum.rb
@@ -76,7 +76,10 @@ class Forgery::LoremIpsum < Forgery
     start = range.first * options[:sentences]
     count = range.count
 
-    return '' if count == 0
+    if count == 0
+      return if block_given?
+      return ''
+    end
 
     next_paragraph = proc {
       paragraph = (

--- a/lib/forgery/forgery/lorem_ipsum.rb
+++ b/lib/forgery/forgery/lorem_ipsum.rb
@@ -75,7 +75,7 @@ class Forgery::LoremIpsum < Forgery
     range = range_from_quantity(quantity, options)
     start = range.first * options[:sentences]
 
-    enumer = range.to_a.length.enum_for(:times).lazy.map do
+    enumer = range.count.enum_for(:times).lazy.map do
       paragraph = (
         options[:wrap][:start] +
         dictionaries[:lorem_ipsum][start..(start+options[:sentences]-1)].join(" ") +

--- a/spec/forgery/lorem_ipsum_spec.rb
+++ b/spec/forgery/lorem_ipsum_spec.rb
@@ -58,6 +58,14 @@ describe Forgery::LoremIpsum do
       end
     end
 
+    it "should always return nil when block_given?" do
+      expect(Forgery::LoremIpsum.paragraphs(0) do end).to be_nil
+      expect(Forgery::LoremIpsum.paragraphs(1) do end).to be_nil
+      expect(Forgery::LoremIpsum.paragraphs(2) do end).to be_nil
+      expect(Forgery::LoremIpsum.paragraphs(3) do end).to be_nil
+      expect(Forgery::LoremIpsum.paragraphs(4) do end).to be_nil
+    end
+
   end
 
   describe ".paragraph" do

--- a/spec/forgery/lorem_ipsum_spec.rb
+++ b/spec/forgery/lorem_ipsum_spec.rb
@@ -38,6 +38,26 @@ describe Forgery::LoremIpsum do
     it "should separate paragraphs with the specified string" do
       expect(Forgery::LoremIpsum.paragraphs(2, :separator => "foo").split("foo").size).to eq(2)
     end
+
+    it "should yield no separator in the last iteration for a given block" do
+      for i in 1..5 do
+        separator = ' xxx '
+        Forgery::LoremIpsum.paragraphs(i, :separator => separator) do |par, sep|
+          separator = sep
+        end
+        expect(separator).to be_nil
+      end
+    end
+
+    it "should yield the exact same paragraphs and separators to a given block" do
+      for i in 0..5 do
+        args = [i, {:separator => ' xxx '}]
+        retval_no_block = Forgery::LoremIpsum.paragraphs(*args)
+        retval_wt_block = Forgery::LoremIpsum.enum_for(:paragraphs, *args).map { |p,s| "#{p}#{s}" }.join
+        expect(retval_wt_block).to eq(retval_no_block)
+      end
+    end
+
   end
 
   describe ".paragraph" do


### PR DESCRIPTION
I have made LoremIpsum#parahraph() yield each paragraph, if a block is given. Otherwise it behaves exactly as before (returns a string of paragraphs). All the options that would be taken into account when returning a string are also honored when yielding paragraphs, **except for** _separator_.

For instance

```
Forgery(:lorem_ipsum).paragraphs(2) do |paragraph| puts paragraph end
```

would print each paragraph.

Of course, for a more coherent API, the same feature should be there with every other method of lorem ipsum (and perhaps other generators as well).

Also, I am not sure how the _separator_ option should be taken into account when using the _yield_ feature of the method, but my opinion is that the caller can use their separator inside the block they provide directly.

Finally, if I had to propose a cleaner API reform, I would factor out the generation code into _each_\_\* methods, and make normal methods be simple wrappers for their _each__ corresponding ones. For example:

```
def each_paragraph(number_of_paragraphs)
  return enum_for(:each_paragraph, number_of_paragraphs) unless block_given?
  number_of_paragraphs.times do
    yield generate_paragraph
  end
end

def paragraphs(num, opts)
  each_paragraph(num).to_a.join(opts[:separator])
end
```

If people find this an interesting idea, I could continue this idea in some future commits.
