### PR TITLE
Use File.exist? instead of deprecated File.exists?

### DIFF
--- a/lib/forgery/file_reader.rb
+++ b/lib/forgery/file_reader.rb
@@ -29,7 +29,7 @@ class Forgery
     def self.find_file(name, folder)
       Forgery.load_paths.reverse.each do |path|
         file = "#{path}/#{folder}/#{name}"
-        return file if File.exists?(file)
+        return file if File.exist?(file)
       end
       raise ArgumentError.new("File '#{name}' wasn't found in '#{folder}' folder. Searched paths: \n#{Forgery.load_paths.join('\n')}")
     end


### PR DESCRIPTION
This fixes deprecation warnings like those:

```
/ruby-2.1.5/gems/forgery-0.6.0/lib/forgery/file_reader.rb:32: warning: File.exists? is a deprecated name, use File.exist? instead
```