### PR TITLE
FIX: warning: constant ::Fixnum is deprecated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    rake (10.1.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    diff-lcs (1.3)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -25,3 +30,6 @@ DEPENDENCIES
   forgery!
   rake
   rspec
+
+BUNDLED WITH
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forgery (0.6.0)
+    forgery (0.6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -26,7 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (~> 1.14.6)
   forgery!
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    forgery (0.6.1)
+    forgery (0.6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -26,7 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.14.6)
+  bundler (~> 1.3)
   forgery!
   rake
   rspec

--- a/forgery.gemspec
+++ b/forgery.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files spec`.split($/)
   spec.require_paths = %w(lib)
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.14.6"
 end

--- a/lib/forgery/version.rb
+++ b/lib/forgery/version.rb
@@ -1,3 +1,3 @@
 class Forgery
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/lib/forgery/version.rb
+++ b/lib/forgery/version.rb
@@ -1,3 +1,3 @@
 class Forgery
-  VERSION = "0.6.1"
+  VERSION = "0.6.0"
 end

--- a/spec/forgery_spec.rb
+++ b/spec/forgery_spec.rb
@@ -53,11 +53,11 @@ describe Forgery do
   end
 
   it "should not be a rails environment when there is not a rails_root" do
-    expect(Forgery.rails?).to be_false
+    expect(Forgery.rails?).to be false
   end
 
   it "should be a rails environment when there is a rails_root" do
     allow(Forgery).to receive(:rails?).and_return(true)
-    expect(Forgery.rails?).to be_true
+    expect(Forgery.rails?).to be true
   end
 end


### PR DESCRIPTION
Just small gems update to fix deprecation warning.